### PR TITLE
[codex] Refresh portfolio design and theme controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,22 +60,17 @@
     <style>
       html,
       body {
-        height: 100vh;
-        width: 100vw;
+        min-height: 100%;
+        width: 100%;
       }
 
       body {
-        flex: 1 1 auto;
         min-height: 100vh;
-        min-width: 100vw;
-        display: flex;
+        margin: 0;
       }
 
       body > #root {
-        flex: 1 1 auto;
         min-height: 100vh;
-        display: flex;
-        flex-direction: column;
         font-family: 'Mukta Mahee', sans-serif;
       }
     </style>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,86 +1,205 @@
 import Hero from '@/components/Hero'
 import { Box, createTheme, CssBaseline, ThemeProvider } from '@mui/material'
+import type { PaletteMode } from '@mui/material'
+import { useMemo, useState } from 'react'
 import AboutMe from './components/AboutMe'
 import Blog from './components/Blog'
 import Footer from './components/Footer'
 import Projects from './components/Projects'
 import Skills from './components/Skills'
+import ThemeToggle from './components/ThemeToggle'
 
-const theme = createTheme({
-  palette: {
-    background: {
-      default: '#FBFBFB',
-      paper: '#c6d9ff',
+function buildTheme(mode: PaletteMode) {
+  const isDark = mode === 'dark'
+
+  return createTheme({
+    palette: {
+      mode,
+      background: {
+        default: isDark ? '#07111f' : '#f7f4ef',
+        paper: isDark ? '#10243a' : '#fbfaf7',
+      },
+      primary: {
+        main: isDark ? '#dce8ff' : '#00224e',
+        dark: isDark ? '#a7c3f5' : '#001936',
+        light: isDark ? '#f4f7ff' : '#2c527f',
+      },
+      secondary: {
+        main: isDark ? '#9db8aa' : '#557768',
+        dark: isDark ? '#6d8f80' : '#36594c',
+        light: isDark ? '#c4d8ce' : '#7e9d90',
+      },
+      warning: {
+        main: isDark ? '#f0b47a' : '#c96f3d',
+        dark: isDark ? '#d6965f' : '#9f4f28',
+        light: isDark ? '#f8d3ad' : '#e2a06e',
+      },
+      info: {
+        main: isDark ? '#b9bed8' : '#747f9f',
+      },
+      text: {
+        primary: isDark ? '#edf4ff' : '#00224e',
+        secondary: isDark ? '#b6c7df' : '#536579',
+      },
+      divider: isDark ? 'rgba(220, 232, 255, 0.18)' : 'rgba(0, 34, 78, 0.14)',
+      common: {
+        white: '#fbfbfb',
+      },
     },
-    primary: {
-      main: '#00224e',
+    shape: {
+      borderRadius: 8,
     },
-    secondary: {
-      main: '#c6d9ff',
+    typography: {
+      fontFamily: ['Mukta Mahee', 'sans-serif'].join(','),
+      h1: {
+        fontWeight: 800,
+        fontSize: '4.75rem',
+        lineHeight: 0.95,
+        letterSpacing: 0,
+      },
+      h2: {
+        fontWeight: 800,
+        fontSize: '2.25rem',
+        lineHeight: 1.12,
+        letterSpacing: 0,
+      },
+      h3: {
+        fontWeight: 800,
+        letterSpacing: 0,
+      },
+      h4: {
+        fontWeight: 800,
+        letterSpacing: 0,
+      },
+      h5: {
+        fontWeight: 700,
+        letterSpacing: 0,
+      },
+      h6: {
+        fontWeight: 700,
+        letterSpacing: 0,
+      },
+      overline: {
+        fontFamily: ['IBM Plex Mono', 'monospace'].join(','),
+        fontWeight: 700,
+        letterSpacing: 0,
+      },
+      subtitle1: {
+        fontWeight: 700,
+      },
+      body1: {
+        fontSize: 18,
+        lineHeight: 1.7,
+      },
+      body2: {
+        lineHeight: 1.65,
+      },
+      button: {
+        fontWeight: 800,
+        letterSpacing: 0,
+        textTransform: 'none',
+      },
     },
-    text: {
-      primary: '#00224e',
-      secondary: '#c6d9ff',
+    breakpoints: {
+      values: {
+        xs: 0,
+        sm: 700,
+        md: 850,
+        lg: 1024,
+        xl: 1280,
+      },
     },
-    common: {
-      white: '#FBFBFB',
+    components: {
+      MuiCssBaseline: {
+        styleOverrides: {
+          html: {
+            minHeight: '100%',
+            scrollBehavior: 'smooth',
+          },
+          body: {
+            minHeight: '100%',
+            width: '100%',
+            overflowX: 'clip',
+          },
+          '#root': {
+            minHeight: '100vh',
+          },
+          '::selection': {
+            backgroundColor: isDark ? '#36594c' : '#d9eadf',
+          },
+          '@media (prefers-reduced-motion: reduce)': {
+            '*, *::before, *::after': {
+              animationDuration: '0.01ms !important',
+              animationIterationCount: '1 !important',
+              scrollBehavior: 'auto !important',
+              transitionDuration: '0.01ms !important',
+            },
+          },
+        },
+      },
+      MuiButton: {
+        styleOverrides: {
+          root: {
+            borderRadius: 8,
+            minHeight: 44,
+            paddingInline: 18,
+            transition:
+              'transform 180ms ease, box-shadow 180ms ease, background-color 180ms ease',
+            '&:hover': {
+              transform: 'translateY(-2px)',
+            },
+            '&.Mui-focusVisible': {
+              outline: `3px solid ${isDark ? '#f0b47a' : '#c96f3d'}`,
+              outlineOffset: 3,
+            },
+          },
+        },
+      },
+      MuiCard: {
+        styleOverrides: {
+          root: {
+            borderRadius: 8,
+          },
+        },
+      },
+      MuiChip: {
+        styleOverrides: {
+          root: {
+            borderRadius: 999,
+            fontWeight: 700,
+          },
+        },
+      },
     },
-  },
-  typography: {
-    fontFamily: ['Mukta Mahee', 'sans-serif'].join(','),
-    h1: {
-      fontWeight: 800,
-      fontSize: 'clamp(2.5rem, 13vw, 4.75rem)',
-      lineHeight: 0.95,
-      letterSpacing: '-0.04em',
-    },
-    h2: {
-      fontWeight: 700,
-    },
-    h3: {
-      fontWeight: 700,
-    },
-    h4: {
-      fontWeight: 700,
-    },
-    h5: {
-      fontWeight: 700,
-    },
-    h6: {
-      fontWeight: 600,
-    },
-    subtitle1: {
-      fontWeight: 600,
-    },
-    body1: {
-      fontSize: 18,
-      lineHeight: 1.7,
-    },
-  },
-  breakpoints: {
-    values: {
-      xs: 0,
-      sm: 700,
-      md: 850,
-      lg: 1024,
-      xl: 1280,
-    },
-  },
-})
+  })
+}
 
 export default function App() {
+  const [selectedMode, setSelectedMode] = useState<PaletteMode>('light')
+  const mode = selectedMode
+  const theme = useMemo(() => buildTheme(mode), [mode])
+
+  const handleThemeToggle = () => {
+    setSelectedMode((currentMode) =>
+      currentMode === 'dark' ? 'light' : 'dark',
+    )
+  }
+
   return (
     <ThemeProvider theme={theme}>
       <CssBaseline />
       <Box
         component='main'
         sx={{
-          backgroundColor: theme.palette.common.white,
+          backgroundColor: 'background.default',
+          color: 'text.primary',
+          minHeight: '100vh',
           width: '100%',
-          maxWidth: '100vw',
-          overflowX: 'hidden',
+          maxWidth: '100%',
+          overflowX: 'clip',
         }}
       >
+        <ThemeToggle mode={mode} onToggle={handleThemeToggle} />
         <Hero />
         <AboutMe />
         <Projects />

--- a/src/components/AboutMe.tsx
+++ b/src/components/AboutMe.tsx
@@ -1,5 +1,21 @@
-import { Divider, Typography } from '@mui/material'
+import { Box, Stack, Typography } from '@mui/material'
 import Grid from '@mui/material/Grid'
+import SectionHeading from './SectionHeading'
+
+const WORKING_PRINCIPLES = [
+  {
+    title: 'Communicative',
+    body: 'Clear, collaborative communication across product, design, backend, and client teams.',
+  },
+  {
+    title: 'Creative',
+    body: 'Comfortable prototyping, experimenting, and turning feedback into practical improvements.',
+  },
+  {
+    title: 'Team spirit',
+    body: 'Adaptive, collaborative, and focused on consistent impact in cross-functional teams.',
+  },
+]
 
 export default function AboutMe() {
   return (
@@ -10,7 +26,7 @@ export default function AboutMe() {
       justifyContent='center'
       alignItems='center'
       sx={{
-        backgroundColor: 'common.white',
+        backgroundColor: 'background.paper',
         px: { xs: 2, sm: 4, md: 6, lg: 8 },
         py: { xs: 5, sm: 7, md: 9 },
       }}
@@ -18,41 +34,74 @@ export default function AboutMe() {
     >
       <Grid
         container
-        direction='column'
         maxWidth='xl'
         width='100%'
-        mb={2}
-        alignItems='center'
+        spacing={3}
+        alignItems='flex-start'
       >
-        <Typography variant='h2' fontSize={36} mb={2} textAlign='center'>
-          About me
-        </Typography>
-        <Divider
-          sx={{
-            width: '100%',
-            maxWidth: 'xl',
-            mx: 'auto',
-            height: 2,
-            bgcolor: 'primary.main',
-            borderRadius: 1,
-            mb: 3,
-          }}
-        />
-        <Grid container direction='column' gap={2}>
-          <Typography variant='body1' color='primary'>
-            I love challenges, technology and learning. I like to be part of the
-            process of creating and evolving a project.
-          </Typography>
-          <Typography variant='body1' color='primary'>
-            I deal with situations proactively and adapt to changes. I like to
-            receive different stimuli, creative, logical or functional, and take
-            advantage of and learn from them in my day to day.
-          </Typography>
-          <Typography variant='body1' color='primary'>
-            I have more than 10 years of experience building scalable web
-            applications, GIS platforms, and AI-powered products for public and
-            private organizations.
-          </Typography>
+        <Grid size={12}>
+          <SectionHeading
+            align='left'
+            eyebrow='About'
+            title='About me'
+            description='Frontend Engineer with 10+ years of experience in scalable web apps, GIS platforms, and AI-powered products.'
+          />
+        </Grid>
+
+        <Grid size={12}>
+          <Grid container spacing={{ xs: 4, md: 7 }} alignItems='flex-start'>
+            <Grid size={{ xs: 12, md: 7 }}>
+              <Stack spacing={2}>
+                <Typography variant='body1' color='text.primary'>
+                  I design and build responsive frontend architectures for
+                  complex products, with a strong focus on performance,
+                  accessibility, and clear user experience across devices.
+                </Typography>
+                <Typography variant='body1' color='text.primary'>
+                  My work spans GIS platforms, AI-driven tools, conversational
+                  interfaces, and enterprise applications for public and private
+                  clients.
+                </Typography>
+                <Typography variant='body1' color='text.primary'>
+                  I have more than 10 years of experience collaborating in
+                  cross-functional teams, mentoring developers, leading
+                  prototypes, and turning product ideas into reliable, scalable
+                  web applications.
+                </Typography>
+              </Stack>
+            </Grid>
+
+            <Grid size={{ xs: 12, md: 5 }}>
+              <Box
+                component='aside'
+                aria-label='Working principles'
+                sx={{
+                  borderLeft: { xs: 0, md: '3px solid' },
+                  borderTop: { xs: '3px solid', md: 0 },
+                  borderColor: 'secondary.main',
+                  pl: { xs: 0, md: 3 },
+                  pt: { xs: 3, md: 0 },
+                }}
+              >
+                <Stack spacing={2.5}>
+                  {WORKING_PRINCIPLES.map((principle) => (
+                    <Box key={principle.title}>
+                      <Typography
+                        variant='overline'
+                        color='secondary.main'
+                        sx={{ lineHeight: 1.4 }}
+                      >
+                        {principle.title}
+                      </Typography>
+                      <Typography variant='body1' color='text.secondary'>
+                        {principle.body}
+                      </Typography>
+                    </Box>
+                  ))}
+                </Stack>
+              </Box>
+            </Grid>
+          </Grid>
         </Grid>
       </Grid>
     </Grid>

--- a/src/components/ActionButtons.tsx
+++ b/src/components/ActionButtons.tsx
@@ -1,11 +1,14 @@
 import Pdf from '@/assets/IkerGarcia_CV.pdf'
+import DownloadIcon from '@mui/icons-material/Download'
+import MailOutlineIcon from '@mui/icons-material/MailOutline'
 import { Button } from '@mui/material'
+import type { ButtonProps } from '@mui/material'
 import Grid from '@mui/material/Grid'
 
 export default function ActionButtons({
   justifyContent = 'flex-start',
   color = 'primary',
-}: Partial<{ justifyContent: string; color: 'primary' | 'secondary' }>) {
+}: Partial<{ justifyContent: string; color: ButtonProps['color'] }>) {
   return (
     <Grid
       container
@@ -19,9 +22,14 @@ export default function ActionButtons({
         component='a'
         color={color}
         href={Pdf}
+        rel='noreferrer'
         target='_blank'
-        variant='outlined'
-        sx={{ minHeight: 44 }}
+        variant='contained'
+        startIcon={<DownloadIcon />}
+        sx={{
+          boxShadow: '0 12px 30px rgba(0, 34, 78, 0.18)',
+          width: { xs: '100%', sm: 'auto' },
+        }}
       >
         Download CV
       </Button>
@@ -32,7 +40,8 @@ export default function ActionButtons({
         href='mailto:ikergarciadev@gmail.com'
         target='_blank'
         rel='noreferrer'
-        sx={{ minHeight: 44 }}
+        startIcon={<MailOutlineIcon />}
+        sx={{ width: { xs: '100%', sm: 'auto' } }}
       >
         Email me
       </Button>

--- a/src/components/Blog.tsx
+++ b/src/components/Blog.tsx
@@ -1,13 +1,15 @@
 import {
-  Box,
   Card,
   CardActionArea,
   CardContent,
   CardMedia,
+  Chip,
+  Stack,
   Typography,
 } from '@mui/material'
 import Grid from '@mui/material/Grid'
 import { posts } from '../data/posts'
+import SectionHeading from './SectionHeading'
 
 export default function Blog() {
   return (
@@ -17,36 +19,23 @@ export default function Blog() {
       direction='column'
       alignItems='center'
       sx={{
-        backgroundColor: 'background.default',
+        background: (theme) =>
+          theme.palette.mode === 'dark'
+            ? 'linear-gradient(180deg, #07111f 0%, #241b18 100%)'
+            : 'linear-gradient(180deg, #f7f4ef 0%, #f1e7dc 100%)',
         px: { xs: 2, sm: 4, md: 6, lg: 8 },
         py: { xs: 5, sm: 7, md: 9 },
       }}
-      gap={3}
+      gap={{ xs: 3.5, md: 5 }}
       width='100%'
     >
-      <Typography variant='h2' fontSize={36} textAlign='center'>
-        Silencio en la Sala
-      </Typography>
-      <Box
-        sx={{
-          width: '100%',
-          maxWidth: 'xl',
-          mx: 'auto',
-          height: 2,
-          bgcolor: 'primary.main',
-          borderRadius: 1,
-          mb: 3,
-        }}
+      <SectionHeading
+        eyebrow='Creative writing'
+        title='Silencio en la Sala'
+        tone='editorial'
+        description='A personal space where poems, haikus, micro-stories, and literary experiments are stripped down to their essence and given room to resonate.'
       />
 
-      <Grid container direction='column' maxWidth='lg'>
-        <Typography variant='body1' color='primary'>
-          A personal space where I publish poems, haikus, micro-stories, and
-          literary experiments. It’s a creative playground where words are
-          stripped down to their essence and given room to resonate. A living
-          collection of writing, always growing and shifting.
-        </Typography>
-      </Grid>
       <Grid
         container
         spacing={3}
@@ -57,35 +46,61 @@ export default function Blog() {
         {posts.map((post) => (
           <Grid key={post.id} size={{ xs: 12, sm: 6, lg: 3 }}>
             <Card
-              elevation={3}
+              elevation={0}
               sx={{
                 height: '100%',
-                backgroundColor: 'common.white',
+                backgroundColor: 'background.paper',
+                border: '1px solid',
+                borderColor: 'divider',
+                borderRadius: 1,
+                boxShadow: '0 16px 36px rgba(76, 46, 31, 0.14)',
+                overflow: 'hidden',
+                transition:
+                  'transform 220ms ease, box-shadow 220ms ease, border-color 220ms ease',
+                '&:hover': {
+                  borderColor: 'warning.main',
+                  boxShadow: '0 22px 52px rgba(76, 46, 31, 0.2)',
+                  transform: 'translateY(-4px)',
+                },
               }}
             >
               <CardActionArea
                 component='a'
                 href={post.href}
                 target='_blank'
-                sx={{ p: 2, height: '100%' }}
+                rel='noreferrer'
+                sx={{ p: 1.5, height: '100%' }}
               >
                 <CardMedia
                   component='img'
-                  height='200'
                   image={post.image}
                   alt={post.title}
-                  loading='lazy'
-                  sx={{ objectFit: 'cover' }}
+                  loading='eager'
+                  sx={{
+                    aspectRatio: '4 / 3',
+                    borderRadius: 0.75,
+                    filter: 'saturate(0.88) contrast(0.98)',
+                    objectFit: 'cover',
+                    width: '100%',
+                  }}
                 />
-                <CardContent>
-                  <Typography
-                    variant='h6'
-                    component='h3'
-                    sx={{ lineHeight: 1.2, textAlign: 'center' }}
-                    color='#828ca4'
-                  >
-                    {post.title}
-                  </Typography>
+                <CardContent sx={{ px: 1, pb: 1, pt: 2 }}>
+                  <Stack spacing={1} alignItems='center'>
+                    <Chip
+                      label='Read collection'
+                      size='small'
+                      color='warning'
+                      variant='outlined'
+                    />
+                    <Typography
+                      variant='h6'
+                      component='h3'
+                      sx={{ color: 'primary.main', lineHeight: 1.2 }}
+                      textAlign='center'
+                    >
+                      {post.title}
+                    </Typography>
+                  </Stack>
                 </CardContent>
               </CardActionArea>
             </Card>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,4 +1,4 @@
-import { Box, Typography } from '@mui/material'
+import { Box, Stack, Typography } from '@mui/material'
 import Grid from '@mui/material/Grid'
 import ActionButtons from './ActionButtons'
 import SocialLinks from './SocialLinks'
@@ -12,11 +12,14 @@ export default function Footer() {
       alignItems='center'
       textAlign='center'
       sx={{
-        minHeight: 220,
-        backgroundColor: 'primary.main',
-        color: 'secondary.main',
+        background: (theme) =>
+          theme.palette.mode === 'dark'
+            ? 'linear-gradient(180deg, #07111f 0%, #020812 100%)'
+            : 'linear-gradient(180deg, #00224e 0%, #001936 100%)',
+        color: '#dce8ff',
+        minHeight: 280,
         px: { xs: 2, sm: 4, md: 6, lg: 8 },
-        py: { xs: 4, sm: 5 },
+        py: { xs: 5, sm: 6 },
       }}
       width='100%'
     >
@@ -28,16 +31,33 @@ export default function Footer() {
         width='100%'
         alignItems={'center'}
         justifyContent={'center'}
+        gap={2}
       >
+        <Stack spacing={1} alignItems='center'>
+          <Typography
+            variant='overline'
+            sx={{ color: '#9db8aa', lineHeight: 1.4 }}
+          >
+            Frontend · AI · Writing
+          </Typography>
+          <Typography
+            variant='h2'
+            sx={{ color: '#dce8ff', fontSize: { xs: 30, sm: 36 } }}
+          >
+            Let’s build something clear.
+          </Typography>
+        </Stack>
         <SocialLinks color='secondary' justifyContent='center' />
         <ActionButtons color='secondary' justifyContent='center' />
-        <Grid>
-          <Box>
-            <Typography variant='body1' fontSize='medium' color='secondary'>
-              @flipasg
-            </Typography>
-          </Box>
-        </Grid>
+        <Box>
+          <Typography
+            variant='body1'
+            fontSize='medium'
+            sx={{ color: '#dce8ff' }}
+          >
+            @flipasg
+          </Typography>
+        </Box>
       </Grid>
     </Grid>
   )

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,20 +1,25 @@
 import Logo from '@/assets/logo-primary.png'
-import { Box, Chip, Stack, Typography } from '@mui/material'
+import LogoWhite from '@/assets/logo-white.png'
+import { Box, Chip, Stack, Typography, useTheme } from '@mui/material'
 import Grid from '@mui/material/Grid'
 import ActionButtons from './ActionButtons'
 import SocialLinks from './SocialLinks'
 
 export default function Hero() {
+  const theme = useTheme()
+
   return (
     <Grid
       container
       component='section'
       sx={{
-        background:
-          'linear-gradient(145deg, #c6d9ff 0%, #eef4ff 48%, #fbfbfb 100%)',
+        background: (theme) =>
+          theme.palette.mode === 'dark'
+            ? 'linear-gradient(135deg, #07111f 0%, #10243a 58%, #17332d 100%)'
+            : 'linear-gradient(135deg, #dce8ff 0%, #f7f4ef 58%, #edf5ef 100%)',
         px: { xs: 2, sm: 4, md: 6, lg: 8 },
-        py: { xs: 6, sm: 8, md: 10, lg: 12 },
-        minHeight: { xs: 'auto', md: '82vh' },
+        py: { xs: 6, sm: 8, md: 10, lg: 11 },
+        minHeight: { xs: 'auto', md: '88vh' },
       }}
       width='100%'
       justifyContent='center'
@@ -26,7 +31,7 @@ export default function Hero() {
         width='100%'
         maxWidth='xl'
         spacing={{ xs: 4, md: 8, lg: 10 }}
-        sx={{ flexDirection: { xs: 'column-reverse', md: 'row' } }}
+        sx={{ flexDirection: { xs: 'column', md: 'row' } }}
       >
         <Grid size={{ xs: 12, md: 7, lg: 7 }}>
           <Stack
@@ -34,14 +39,30 @@ export default function Hero() {
             spacing={{ xs: 2, sm: 2.5 }}
             alignItems={{ xs: 'center', md: 'flex-start' }}
             textAlign={{ xs: 'center', md: 'left' }}
+            sx={{
+              '@keyframes heroFadeUp': {
+                from: { opacity: 0, transform: 'translateY(16px)' },
+                to: { opacity: 1, transform: 'translateY(0)' },
+              },
+              animation: 'heroFadeUp 520ms ease both',
+            }}
           >
             <Chip
-              label='Available for frontend and AI product work'
-              color='primary'
+              label='Engineer by trade. Writer by instinct.'
+              color='secondary'
               variant='outlined'
               sx={{
                 borderWidth: 2,
-                bgcolor: 'rgba(251, 251, 251, 0.72)',
+                bgcolor: (theme) =>
+                  theme.palette.mode === 'dark'
+                    ? 'rgba(220, 232, 255, 0.94)'
+                    : 'rgba(251, 250, 247, 0.72)',
+                borderColor: (theme) =>
+                  theme.palette.mode === 'dark'
+                    ? 'rgba(220, 232, 255, 0.94)'
+                    : 'secondary.main',
+                color: (theme) =>
+                  theme.palette.mode === 'dark' ? '#07111f' : 'primary.main',
                 fontWeight: 800,
                 maxWidth: '100%',
                 height: 'auto',
@@ -56,16 +77,17 @@ export default function Hero() {
             <Typography
               variant='overline'
               color='primary'
-              sx={{ fontWeight: 800, letterSpacing: 2 }}
+              sx={{ fontWeight: 800 }}
             >
-              Portfolio · Frontend · AI products
+              Frontend · AI · Writing
             </Typography>
             <Typography
               variant='h1'
               sx={{
                 color: 'primary.main',
-                maxWidth: 980,
-                whiteSpace: { xs: 'normal', lg: 'nowrap' },
+                fontSize: { xs: 34, sm: 54, md: 58, lg: 64 },
+                maxWidth: '100%',
+                whiteSpace: 'nowrap',
               }}
             >
               Iker Garcia Ramirez
@@ -79,7 +101,7 @@ export default function Hero() {
                 maxWidth: 760,
               }}
             >
-              Frontend Engineer building responsive, accessible web products.
+              Frontend Engineer building useful, accessible web products.
             </Typography>
             <Typography
               variant='body1'
@@ -91,7 +113,8 @@ export default function Hero() {
             >
               I turn complex product ideas into fast interfaces with clear
               structure, pragmatic engineering, and careful attention to how
-              people use them across devices.
+              people use them across devices. My creative writing practice keeps
+              that work grounded in rhythm, clarity, and human context.
             </Typography>
             <SocialLinks />
             <ActionButtons />
@@ -103,13 +126,18 @@ export default function Hero() {
         >
           <Box
             component='img'
-            alt='Iker Garcia'
-            src={Logo}
+            alt='Iker Garcia personal mark'
+            src={theme.palette.mode === 'dark' ? LogoWhite : Logo}
             sx={{
-              width: { xs: 190, sm: 240, md: 320, lg: 380 },
+              width: { xs: 142, sm: 190, md: 320, lg: 380 },
               maxWidth: '100%',
               height: 'auto',
               display: 'block',
+              filter: (theme) =>
+                theme.palette.mode === 'dark'
+                  ? 'drop-shadow(0 24px 50px rgba(0, 0, 0, 0.28))'
+                  : 'drop-shadow(0 24px 50px rgba(0, 34, 78, 0.12))',
+              opacity: { xs: 0.86, md: 1 },
             }}
           />
         </Grid>

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -1,20 +1,42 @@
 import { PROJECTS, type Project } from '@/data/projects'
-import { Box, Chip, Stack, Typography } from '@mui/material'
+import OpenInNewIcon from '@mui/icons-material/OpenInNew'
+import { Box, Button, Chip, Stack, Typography } from '@mui/material'
 import Grid from '@mui/material/Grid'
+import SectionHeading from './SectionHeading'
 
-function Tile({ p }: { p: Project }) {
+const PROJECT_ACCENTS = ['#c96f3d', '#557768', '#747f9f', '#9f6a5f', '#b58a44']
+
+function Tile({ p, index }: { p: Project; index: number }) {
+  const tech = Array.from(new Set(p.tech))
+  const accent = PROJECT_ACCENTS[index % PROJECT_ACCENTS.length]
+
   return (
     <Box
       component='article'
       sx={{
         position: 'relative',
-        height: 'auto',
-        borderRadius: 2,
+        height: '100%',
+        border: '1px solid',
+        borderColor: 'divider',
+        borderRadius: 1,
         overflow: 'hidden',
-        boxShadow: '0 10px 28px rgba(0, 34, 78, 0.2)',
-        bgcolor: 'primary.main',
+        boxShadow: '0 18px 46px rgba(0, 34, 78, 0.14)',
+        bgcolor: (theme) =>
+          theme.palette.mode === 'dark' ? '#0c1d32' : '#00224e',
+        transition:
+          'transform 220ms ease, box-shadow 220ms ease, border-color 220ms ease',
+        '&::before': {
+          content: '""',
+          position: 'absolute',
+          insetBlock: 0,
+          left: 0,
+          width: 5,
+          bgcolor: accent,
+        },
         '&:hover': {
-          boxShadow: '0 16px 44px rgba(0, 34, 78, 0.32)',
+          borderColor: accent,
+          boxShadow: '0 24px 60px rgba(0, 34, 78, 0.24)',
+          transform: 'translateY(-4px)',
         },
       }}
     >
@@ -24,48 +46,91 @@ function Tile({ p }: { p: Project }) {
           display: 'flex',
           flexDirection: 'column',
           justifyContent: 'space-between',
-          p: { xs: 2.5, sm: 3 },
+          p: { xs: 2.5, sm: 3.25 },
+          pl: { xs: 3.25, sm: 4 },
+          minHeight: '100%',
         }}
       >
-        <Box>
+        <Stack spacing={1.25}>
+          <Stack
+            direction={{ xs: 'column', sm: 'row' }}
+            spacing={1}
+            alignItems={{ xs: 'flex-start', sm: 'center' }}
+            justifyContent='space-between'
+          >
+            <Typography
+              variant='overline'
+              sx={{ color: 'rgba(220, 232, 255, 0.76)', lineHeight: 1.4 }}
+            >
+              {p.title}
+            </Typography>
+            {p.period ? (
+              <Chip
+                label={p.period}
+                size='small'
+                sx={{
+                  bgcolor: 'rgba(255, 255, 255, 0.12)',
+                  color: '#dce8ff',
+                }}
+              />
+            ) : null}
+          </Stack>
           <Typography
-            variant='h4'
+            variant='h3'
             sx={{
               fontWeight: 800,
-              mt: 1,
-              fontSize: { xs: 24, sm: 28, md: 32 },
+              fontSize: { xs: 26, sm: 30, md: 34 },
+              lineHeight: 1.08,
             }}
-            color='text.secondary'
+            color='#dce8ff'
           >
             {p.role}
           </Typography>
-          <Typography
-            variant='subtitle1'
-            sx={{ display: 'block', opacity: 0.9, mt: 0.5 }}
-            color='secondary'
-          >
-            {p.company}
-          </Typography>
-          <Typography
-            variant='subtitle2'
-            sx={{ display: 'block', opacity: 0.7, mt: 0.5 }}
-            color='text.secondary'
-          >
-            {p.period}
-          </Typography>
-        </Box>
+          {p.href ? (
+            <Button
+              component='a'
+              href={p.href}
+              target='_blank'
+              rel='noreferrer'
+              color='secondary'
+              size='small'
+              variant='text'
+              endIcon={<OpenInNewIcon fontSize='small' />}
+              sx={{
+                alignSelf: 'flex-start',
+                color: '#c4d8ce',
+                minHeight: 0,
+                px: 0,
+                py: 0.25,
+                '&:hover': {
+                  bgcolor: 'transparent',
+                  color: '#f0b47a',
+                },
+              }}
+            >
+              {p.company}
+            </Button>
+          ) : (
+            <Typography
+              variant='subtitle1'
+              sx={{ color: '#c4d8ce', display: 'block' }}
+            >
+              {p.company}
+            </Typography>
+          )}
+        </Stack>
         <Box
           sx={{
             borderBottom: '0.5px solid',
-            borderColor: 'background.paper',
-            my: 1,
+            borderColor: 'rgba(220, 232, 255, 0.5)',
+            my: 2,
           }}
         />
 
         <Box>
           <Typography
             variant='body2'
-            sx={{ lineHeight: 1.5, color: 'text.secondary' }}
+            sx={{ color: 'rgba(220, 232, 255, 0.88)', lineHeight: 1.6 }}
           >
             {p.description}
           </Typography>
@@ -73,14 +138,14 @@ function Tile({ p }: { p: Project }) {
 
         <Box>
           <Stack direction='row' flexWrap='wrap' gap={1} sx={{ mt: 2 }}>
-            {p.tech.map((t, i) => (
+            {tech.map((t) => (
               <Chip
-                key={`${p.title}-${t}-${i}`}
+                key={`${p.title}-${t}`}
                 label={t}
                 size='small'
                 sx={{
-                  bgcolor: 'rgba(255,255,255,.15)',
-                  color: 'secondary.main',
+                  bgcolor: 'rgba(255, 255, 255, 0.12)',
+                  color: '#dce8ff',
                   fontWeight: 600,
                 }}
               />
@@ -104,28 +169,19 @@ export default function Projects() {
         px: { xs: 2, sm: 4, md: 6, lg: 8 },
         py: { xs: 5, sm: 7, md: 9 },
       }}
-      gap={3}
+      gap={{ xs: 3.5, md: 5 }}
       width='100%'
     >
-      <Typography variant='h2' fontSize={36} textAlign='center'>
-        Work Experience
-      </Typography>
-      <Box
-        sx={{
-          width: '100%',
-          maxWidth: 'xl',
-          mx: 'auto',
-          height: 2,
-          bgcolor: 'primary.main',
-          borderRadius: 1,
-          mb: 3,
-        }}
+      <SectionHeading
+        eyebrow='Selected work'
+        title='Work Experience'
+        description='A career history across GIS platforms, AI product tooling, data visualization, and accessible frontend systems.'
       />
 
-      <Grid container spacing={2.5} sx={{ maxWidth: 'xl', width: '100%' }}>
-        {PROJECTS.map((p) => (
+      <Grid container spacing={3} sx={{ maxWidth: 'xl', width: '100%' }}>
+        {PROJECTS.map((p, index) => (
           <Grid key={p.title} size={{ xs: 12, sm: 6, md: 6 }}>
-            <Tile p={p} />
+            <Tile p={p} index={index} />
           </Grid>
         ))}
       </Grid>

--- a/src/components/SectionHeading.tsx
+++ b/src/components/SectionHeading.tsx
@@ -1,0 +1,71 @@
+import { Box, Stack, Typography } from '@mui/material'
+import type { ReactNode } from 'react'
+
+type SectionHeadingProps = {
+  eyebrow?: string
+  title: string
+  description?: ReactNode
+  align?: 'center' | 'left'
+  tone?: 'professional' | 'editorial'
+}
+
+export default function SectionHeading({
+  eyebrow,
+  title,
+  description,
+  align = 'center',
+  tone = 'professional',
+}: SectionHeadingProps) {
+  const isCentered = align === 'center'
+  const isEditorial = tone === 'editorial'
+
+  return (
+    <Stack
+      component='header'
+      spacing={1.5}
+      alignItems={isCentered ? 'center' : 'flex-start'}
+      textAlign={align}
+      sx={{ width: '100%', maxWidth: isCentered ? 920 : 760 }}
+    >
+      {eyebrow ? (
+        <Typography
+          variant='overline'
+          color={isEditorial ? 'warning.main' : 'secondary.main'}
+          sx={{ lineHeight: 1.4 }}
+        >
+          {eyebrow}
+        </Typography>
+      ) : null}
+      <Typography
+        variant='h2'
+        sx={{
+          color: 'primary.main',
+          fontSize: { xs: 34, sm: 38, md: 42 },
+        }}
+      >
+        {title}
+      </Typography>
+      <Box
+        aria-hidden='true'
+        sx={{
+          width: { xs: 72, sm: 96 },
+          height: 3,
+          borderRadius: 999,
+          background: (theme) =>
+            isEditorial
+              ? `linear-gradient(90deg, ${theme.palette.secondary.main}, ${theme.palette.warning.main})`
+              : `linear-gradient(90deg, ${theme.palette.primary.main}, ${theme.palette.secondary.main})`,
+        }}
+      />
+      {description ? (
+        <Typography
+          variant='body1'
+          color='text.secondary'
+          sx={{ maxWidth: 900 }}
+        >
+          {description}
+        </Typography>
+      ) : null}
+    </Stack>
+  )
+}

--- a/src/components/Skills.tsx
+++ b/src/components/Skills.tsx
@@ -4,10 +4,14 @@ import BuildIcon from '@mui/icons-material/Build'
 import CloudIcon from '@mui/icons-material/Cloud'
 import CodeIcon from '@mui/icons-material/Code'
 import DesignServicesIcon from '@mui/icons-material/DesignServices'
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import IntegrationInstructionsIcon from '@mui/icons-material/IntegrationInstructions'
 import PsychologyIcon from '@mui/icons-material/Psychology'
 import PublicIcon from '@mui/icons-material/Public'
 import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
   Avatar,
   Card,
   CardContent,
@@ -15,13 +19,14 @@ import {
   Divider,
   Stack,
   Typography,
+  useMediaQuery,
+  useTheme,
 } from '@mui/material'
 import Grid from '@mui/material/Grid'
+import type { ReactNode } from 'react'
+import SectionHeading from './SectionHeading'
 
-const ICONS: Record<
-  SkillIconKey | 'infrastructure' | 'architecture',
-  React.ReactNode
-> = {
+const ICONS: Record<SkillIconKey, ReactNode> = {
   ai: <PsychologyIcon />,
   frontend: <PublicIcon />,
   backend: <CodeIcon />,
@@ -32,7 +37,74 @@ const ICONS: Record<
   architecture: <ArchitectureIcon />,
 }
 
+function SkillChips({
+  categoryTitle,
+  items,
+}: {
+  categoryTitle: string
+  items: string[]
+}) {
+  return (
+    <Stack direction='row' useFlexGap flexWrap='wrap' gap={1}>
+      {items.map((s) => (
+        <Chip
+          key={`${categoryTitle}-${s}`}
+          label={s}
+          size='medium'
+          sx={{
+            bgcolor: 'transparent',
+            borderColor: 'primary.main',
+            color: 'primary.main',
+            fontSize: { xs: 13, sm: 14 },
+            fontWeight: 700,
+          }}
+          variant='outlined'
+        />
+      ))}
+    </Stack>
+  )
+}
+
+function CategoryHeading({
+  icon,
+  title,
+}: {
+  icon: SkillIconKey
+  title: string
+}) {
+  return (
+    <Stack direction='row' alignItems='center' spacing={2}>
+      <Avatar
+        variant='rounded'
+        sx={{
+          bgcolor: 'rgba(85, 119, 104, 0.12)',
+          color: 'primary.main',
+          border: '2px solid',
+          borderColor: 'primary.main',
+          width: 48,
+          height: 48,
+        }}
+      >
+        {ICONS[icon]}
+      </Avatar>
+      <Typography
+        variant='h6'
+        sx={{
+          fontWeight: 800,
+          fontSize: { xs: 18, sm: 20 },
+          color: 'text.primary',
+        }}
+      >
+        {title}
+      </Typography>
+    </Stack>
+  )
+}
+
 export default function Skills() {
+  const theme = useTheme()
+  const isCompact = useMediaQuery(theme.breakpoints.down('sm'))
+
   return (
     <Grid
       container
@@ -41,99 +113,84 @@ export default function Skills() {
       alignItems='center'
       justifyContent={'center'}
       sx={{
+        backgroundColor: 'background.paper',
         px: { xs: 2, sm: 4, md: 6, lg: 8 },
         py: { xs: 5, sm: 7, md: 9 },
       }}
       width={'100%'}
+      gap={{ xs: 3.5, md: 5 }}
     >
-      <Typography variant='h2' fontSize={36} mb={2} textAlign='center'>
-        Skills
-      </Typography>
-      <Divider
-        sx={{
-          width: '100%',
-          maxWidth: 'xl',
-          mx: 'auto',
-          height: 2,
-          bgcolor: 'primary.main',
-          borderRadius: 1,
-          mb: 3,
-        }}
+      <SectionHeading
+        eyebrow='Toolkit'
+        title='Skills'
+        description='A practical mix of frontend systems, AI workflows, geospatial products, architecture, and delivery tooling.'
       />
 
-      <Grid
-        container
-        spacing={3}
-        sx={{ maxWidth: 'xl', mx: 'auto', width: '100%' }}
-      >
-        {SKILLS.map((cat) => (
-          <Grid key={cat.title} size={{ xs: 12, sm: 6, md: 4 }}>
-            <Card
+      {isCompact ? (
+        <Stack spacing={1.5} sx={{ maxWidth: 'xl', mx: 'auto', width: '100%' }}>
+          {SKILLS.map((cat) => (
+            <Accordion
+              key={cat.title}
+              disableGutters
               elevation={0}
               sx={{
-                height: '100%',
-                backgroundColor: 'background.paper',
-                borderRadius: 2,
-                boxShadow: '0 10px 28px rgba(0, 34, 78, 0.14)',
-                transition: 'transform .18s ease, box-shadow .18s ease',
+                bgcolor: 'rgba(220, 232, 255, 0.42)',
+                border: '1px solid',
+                borderColor: 'divider',
+                borderRadius: 1,
+                boxShadow: 'none',
+                overflow: 'hidden',
+                '&::before': { display: 'none' },
               }}
             >
-              <CardContent sx={{ p: { xs: 2.5, sm: 3 } }}>
-                <Stack direction='row' alignItems='center' spacing={2} mb={1.5}>
-                  <Avatar
-                    variant='rounded'
-                    sx={{
-                      bgcolor: 'transparent',
-                      color: 'primary.main',
-                      border: '2px solid',
-                      borderColor: 'primary.main',
-                      width: 48,
-                      height: 48,
-                    }}
-                  >
-                    {ICONS[cat.icon]}
-                  </Avatar>
-                  <Typography
-                    variant='h6'
-                    sx={{
-                      fontWeight: 800,
-                      fontSize: { xs: 18, sm: 20 },
-                      color: 'text.primary',
-                    }}
-                  >
-                    {cat.title}
-                  </Typography>
-                </Stack>
+              <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                <CategoryHeading icon={cat.icon} title={cat.title} />
+              </AccordionSummary>
+              <AccordionDetails sx={{ pt: 0 }}>
+                <SkillChips categoryTitle={cat.title} items={cat.items} />
+              </AccordionDetails>
+            </Accordion>
+          ))}
+        </Stack>
+      ) : (
+        <Grid
+          container
+          spacing={3}
+          sx={{ maxWidth: 'xl', mx: 'auto', width: '100%' }}
+        >
+          {SKILLS.map((cat) => (
+            <Grid key={cat.title} size={{ xs: 12, sm: 6, md: 4 }}>
+              <Card
+                elevation={0}
+                component='article'
+                sx={{
+                  height: '100%',
+                  backgroundColor: 'rgba(220, 232, 255, 0.46)',
+                  border: '1px solid',
+                  borderColor: 'divider',
+                  borderRadius: 1,
+                  boxShadow: '0 16px 38px rgba(0, 34, 78, 0.1)',
+                  transition: 'transform .18s ease, box-shadow .18s ease',
+                  '&:hover': {
+                    boxShadow: '0 22px 52px rgba(0, 34, 78, 0.16)',
+                    transform: 'translateY(-3px)',
+                  },
+                }}
+              >
+                <CardContent sx={{ p: { xs: 2.5, sm: 3 } }}>
+                  <Stack spacing={2}>
+                    <CategoryHeading icon={cat.icon} title={cat.title} />
 
-                <Divider
-                  sx={{
-                    borderColor: 'primary.main',
-                    mb: 2,
-                  }}
-                />
+                    <Divider sx={{ borderColor: 'divider' }} />
 
-                <Stack direction='row' useFlexGap flexWrap='wrap' gap={1}>
-                  {cat.items.map((s, i) => (
-                    <Chip
-                      key={`${cat.title}-${s}-${i}`}
-                      label={s}
-                      size='medium'
-                      sx={{
-                        fontSize: { xs: 13, sm: 14 },
-                        fontWeight: 600,
-                        borderColor: 'primary.main',
-                        bgcolor: 'background.paper',
-                        cursor: 'default',
-                      }}
-                      variant='outlined'
-                    />
-                  ))}
-                </Stack>
-              </CardContent>
-            </Card>
-          </Grid>
-        ))}
-      </Grid>
+                    <SkillChips categoryTitle={cat.title} items={cat.items} />
+                  </Stack>
+                </CardContent>
+              </Card>
+            </Grid>
+          ))}
+        </Grid>
+      )}
     </Grid>
   )
 }

--- a/src/components/SocialLinks.tsx
+++ b/src/components/SocialLinks.tsx
@@ -4,7 +4,7 @@ import InstagramIcon from '@mui/icons-material/Instagram'
 import LinkedInIcon from '@mui/icons-material/LinkedIn'
 import PinterestIcon from '@mui/icons-material/Pinterest'
 import TwitterIcon from '@mui/icons-material/Twitter'
-import { IconButton, Stack, SvgIcon } from '@mui/material'
+import { IconButton, Stack, SvgIcon, Tooltip } from '@mui/material'
 import type { IconButtonProps } from '@mui/material'
 
 const SOCIAL_LINKS = [
@@ -65,22 +65,39 @@ export default function SocialLinks({
       }}
     >
       {SOCIAL_LINKS.map(({ key, label, href, icon }) => (
-        <IconButton
-          key={key}
-          component='a'
-          aria-label={label}
-          target='_blank'
-          rel='noreferrer'
-          href={href}
-          color={color}
-          sx={{
-            border: '1px solid',
-            borderColor:
-              color === 'secondary' ? 'secondary.main' : 'primary.main',
-          }}
-        >
-          <SvgIcon component={icon} />
-        </IconButton>
+        <Tooltip key={key} title={label} arrow>
+          <IconButton
+            component='a'
+            aria-label={label}
+            target='_blank'
+            rel='noreferrer'
+            href={href}
+            color={color}
+            sx={{
+              border: '1px solid',
+              borderColor:
+                color === 'secondary' ? 'secondary.main' : 'primary.main',
+              height: 44,
+              transition:
+                'transform 180ms ease, background-color 180ms ease, border-color 180ms ease',
+              width: 44,
+              '&:hover': {
+                bgcolor:
+                  color === 'secondary'
+                    ? 'rgba(198, 217, 255, 0.12)'
+                    : 'rgba(85, 119, 104, 0.12)',
+                transform: 'translateY(-2px)',
+              },
+              '&.Mui-focusVisible': {
+                outline: '3px solid',
+                outlineColor: 'warning.main',
+                outlineOffset: 3,
+              },
+            }}
+          >
+            <SvgIcon component={icon} fontSize='small' />
+          </IconButton>
+        </Tooltip>
       ))}
     </Stack>
   )

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,47 @@
+import DarkModeIcon from '@mui/icons-material/DarkMode'
+import LightModeIcon from '@mui/icons-material/LightMode'
+import { IconButton, Tooltip } from '@mui/material'
+import type { PaletteMode } from '@mui/material'
+
+type ThemeToggleProps = {
+  mode: PaletteMode
+  onToggle: () => void
+}
+
+export default function ThemeToggle({ mode, onToggle }: ThemeToggleProps) {
+  const isDark = mode === 'dark'
+  const label = isDark ? 'Switch to light theme' : 'Switch to dark theme'
+
+  return (
+    <Tooltip title={label} arrow>
+      <IconButton
+        aria-label={label}
+        color='primary'
+        onClick={onToggle}
+        sx={{
+          position: 'fixed',
+          top: { xs: 12, sm: 20 },
+          right: { xs: 12, sm: 20 },
+          zIndex: (theme) => theme.zIndex.tooltip,
+          bgcolor: isDark ? '#dce8ff' : 'background.paper',
+          border: '1px solid',
+          borderColor: isDark ? '#dce8ff' : 'divider',
+          boxShadow: '0 12px 28px rgba(0, 34, 78, 0.16)',
+          color: isDark ? '#07111f' : 'primary.main',
+          height: 44,
+          width: 44,
+          '&:hover': {
+            bgcolor: isDark ? '#f4f7ff' : 'secondary.light',
+          },
+          '&.Mui-focusVisible': {
+            outline: '3px solid',
+            outlineColor: 'warning.main',
+            outlineOffset: 3,
+          },
+        }}
+      >
+        {isDark ? <LightModeIcon /> : <DarkModeIcon />}
+      </IconButton>
+    </Tooltip>
+  )
+}

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -11,7 +11,7 @@ export type Project = {
 
 export const PROJECTS: Project[] = [
   {
-    title: 'COTESA GIS Solutions',
+    title: 'COTESA - Consultancy, solutions and innovative services',
     role: 'Full Stack Engineer',
     company: 'COTESA',
     period: 'Oct 2025 – Present',
@@ -28,6 +28,7 @@ export const PROJECTS: Project[] = [
       'Data Visualization',
       'Accessibility',
     ],
+    href: 'https://cotesa.com.es/',
     image: 'cotesa',
   },
   {
@@ -55,7 +56,7 @@ export const PROJECTS: Project[] = [
     image: 'frenetic',
   },
   {
-    title: 'CARTO',
+    title: 'CARTO - The Agentic GIS Platform',
     role: 'Frontend Engineer',
     company: 'CARTO',
     period: 'Dec 2021 – May 2023',
@@ -106,7 +107,7 @@ export const PROJECTS: Project[] = [
     image: 'landbot',
   },
   {
-    title: 'Geograma Public Sector GIS',
+    title: 'geograma - GIS y Location Intelligence',
     role: 'Software Engineer',
     company: 'Geograma',
     period: 'Jun 2015 – Apr 2021',

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,11 +1,9 @@
-import { CssBaseline } from '@mui/material'
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App'
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
-    <CssBaseline />
     <App />
   </React.StrictMode>,
 )

--- a/tests/AboutMe.test.tsx
+++ b/tests/AboutMe.test.tsx
@@ -11,6 +11,8 @@ describe('AboutMe', () => {
 
     const paragraphs = container.querySelectorAll('p')
     expect(paragraphs.length).toBeGreaterThanOrEqual(3)
-    expect(screen.getByText(/GIS platforms/i)).toBeInTheDocument()
+    expect(screen.getAllByText(/GIS platforms/i).length).toBeGreaterThanOrEqual(
+      1,
+    )
   })
 })

--- a/tests/SectionHeading.test.tsx
+++ b/tests/SectionHeading.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react'
+import SectionHeading from '../src/components/SectionHeading'
+
+describe('SectionHeading', () => {
+  test('should render eyebrow title and description', () => {
+    render(
+      <SectionHeading
+        eyebrow='Creative writing'
+        title='Silencio en la Sala'
+        description='A personal writing space.'
+        tone='editorial'
+      />,
+    )
+
+    expect(screen.getByText('Creative writing')).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', { name: 'Silencio en la Sala' }),
+    ).toBeInTheDocument()
+    expect(screen.getByText('A personal writing space.')).toBeInTheDocument()
+  })
+})

--- a/tests/ThemeToggle.test.tsx
+++ b/tests/ThemeToggle.test.tsx
@@ -1,0 +1,26 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { vi } from 'vitest'
+import ThemeToggle from '../src/components/ThemeToggle'
+
+describe('ThemeToggle', () => {
+  test('should render dark theme action and call toggle', () => {
+    const onToggle = vi.fn()
+
+    render(<ThemeToggle mode='light' onToggle={onToggle} />)
+
+    const toggle = screen.getByRole('button', {
+      name: 'Switch to dark theme',
+    })
+    fireEvent.click(toggle)
+
+    expect(onToggle).toHaveBeenCalledTimes(1)
+  })
+
+  test('should render light theme action for dark mode', () => {
+    render(<ThemeToggle mode='dark' onToggle={() => undefined} />)
+
+    expect(
+      screen.getByRole('button', { name: 'Switch to light theme' }),
+    ).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- Refreshes the portfolio visual system with a warmer light theme, dark mode support, and a visible theme toggle.
- Updates hero, About, Work Experience, Skills, Blog, and Footer presentation/content.
- Adds shared section heading and interaction polish for buttons/social links.
- Updates project metadata for COTESA, CARTO, and geograma.

## Commit structure
- `feat: add theme toggle foundation`
- `refactor: add shared section controls`
- `feat: update hero about and footer content`
- `feat: refresh portfolio sections`

## Validation
- `npm run typecheck`
- `npm run lint`
- `npm run test`
- `npm run build`

Note: `npm run build` succeeds but Vite prints the existing local Node warning because this machine uses Node 22.2.0 and Vite expects 20.19+ or 22.12+.
